### PR TITLE
yaml.load: The default Loader is unsafe.

### DIFF
--- a/cool_config/cool_config.py
+++ b/cool_config/cool_config.py
@@ -135,7 +135,7 @@ class AbstractConfig(Section):
         :param path: path to file
         """
         with open(path) as f:
-            return self.__load(yaml.load(f))
+            return self.__load(yaml.load(f, Loader=yaml.FullLoader))
 
     def update_from_dict(self, data: dict, allow_missing_keys=True) -> 'AbstractConfig':
         """
@@ -152,7 +152,7 @@ class AbstractConfig(Section):
         :param allow_missing_keys: allowing to update config partially
         """
         with open(path) as f:
-            return self.__load(yaml.load(f), allow_to_fail=allow_missing_keys)
+            return self.__load(yaml.load(f, Loader=yaml.FullLoader), allow_to_fail=allow_missing_keys)
 
     def update_from_env(self, env_prefix: str, delimiter: str='__') -> 'AbstractConfig':
         """


### PR DESCRIPTION
[PyYAML yaml.load(input) Deprecation](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)

> Use of PyYAML's yaml.load function without specifying the Loader=... parameter, has been deprecated. In PyYAML version 5.1, you will get a warning, but the function will still work.

Before PyYAML 5.1, the PyYAML.load function could be easily exploited to call any Python function. That means it could call any system command using os.system(). Here is a trivial example:
```bash
python -c 'import yaml; yaml.load("!!python/object/new:os.system [echo EXPLOIT!]")'
```